### PR TITLE
Add toggle to map auto adjusting to new features

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatCheckboxModule } from '@angular/material/checkbox'; 
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -87,6 +88,7 @@ if ( environment.production ) {
     FormsModule,
     ReactiveFormsModule,
     StorageServiceModule,
+    MatCheckboxModule, 
 
     ColorPickerModule
   ],

--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -137,7 +137,7 @@ mat-progress-spinner {
     display: flex;
     align-items: center;
     gap: 8px;
-    margin-top: 8px;
+    margin: 8px 0px 8px 0px;
     flex-wrap: wrap;
 }
 

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -14,7 +14,7 @@
 <div class="view">
   <mat-sidenav-container class="sidenav-container">
     <mat-sidenav-content>
-      <app-map [rows]="rows" [page]="page" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
+      <app-map [rows]="rows" [page]="page" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles" [autoFitBounds]="autoFitBounds"></app-map>
     </mat-sidenav-content>
     <mat-sidenav #sidenav mode="side" position="start" [(opened)]="sideNavOpened">
       <section class="drawer">
@@ -71,7 +71,9 @@
                 <mat-progress-spinner *ngIf="pending" mode="indeterminate" [diameter]="24" [strokeWidth]="4">
                 </mat-progress-spinner>
               </div>
-              
+              <mat-checkbox [checked]="autoFitBounds" (change)="updateAutoFitBounds($event)" color="primary">
+                Auto adjust map to fit new bounds
+              </mat-checkbox>
               <p class="sql-caption" *ngIf="bytesProcessed >= 0">
                 Estimated query size: {{ bytesProcessed | fileSize:1 }}
               </p>

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -121,12 +121,15 @@ export class MainComponent implements OnInit, OnDestroy {
   // Current style rules
   styles: Array<StyleRule> = [];
 
+  // Toggle for whether the map auto fits bounds on new features
+  autoFitBounds: boolean = true;
+
   // CodeMirror configuration
   readonly cmConfig = {
     indentWithTabs: true,
     smartIndent: true,
     lineNumbers: true,
-    lineWrapping: true
+    lineWrapping: true,
   };
   readonly cmDebouncer: Subject<string> = new Subject();
   cmDebouncerSub: Subscription;
@@ -156,6 +159,7 @@ export class MainComponent implements OnInit, OnDestroy {
     this.geoColumnNames = [];
     this.rows = [];
     this.page = 0;
+    this.autoFitBounds = true;
 
     // Read parameters from URL
     this.projectID = this._route.snapshot.paramMap.get("project");
@@ -555,9 +559,9 @@ ${USER_QUERY_END_MARKER}\n
     this.isEditingPagination = false;
   }
 
-
-
-
+  updateAutoFitBounds(event: any) {
+    this.autoFitBounds = event.checked;
+  }
 
   onApplyStylesClicked() {
     this.clearGeneratedSharingUrl();


### PR DESCRIPTION
#### Description:
- Added a global checkbox toggle for whether the map should resize when the features change.

#### Testing:
- No new errors on `npm test`. 
- Auto adjusting map toggle seems to work as expected for both on and off when querying new data from the "Run" button, using the indexing functionality, and switching between different geography columns from a query like below:
```
SELECT 
    geometry AS glacier_geometry,
    NULL AS whale_geometry
FROM 
    `benioff-ocean-initiative.geojson_examples.glacier`

UNION ALL

SELECT 
    NULL AS glacier_geometry,
    geog AS whale_geometry
FROM 
    `benioff-ocean-initiative.rice_whale.rgns`;
```

#### Relevant Issue:
https://boi-ucsb.atlassian.net/browse/ENG-230?atlOrigin=eyJpIjoiMWI0ZDNmZTUyNmUwNDJlOTliYmY2Y2FjMjY0NWVhOWQiLCJwIjoiaiJ9

#### Relevant Image:
<img width="545" alt="Screenshot 2024-10-14 at 7 02 30 PM" src="https://github.com/user-attachments/assets/8198d283-e9d8-4550-9d14-8b6adbd0a014">
